### PR TITLE
Change bdb version to 18.1.32 (stable)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ find_package(Snappy CONFIG REQUIRED)
 
 find_library(ROCKSDB_LIBRARY rocksdb)
 
-    set(BDB_VER "18.1.40")
+    set(BDB_VER "18.1.32")
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/contrib/cmake")
 set(CMAKE_CXX_STANDARD 11)
 include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)

--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -18,9 +18,10 @@ expand_path() {
 }
 
 BDB_PREFIX="$(expand_path ${1})/db18"; shift;
-BDB_VERSION='db-18.1.40'
-BDB_HASH='0cecb2ef0c67b166de93732769abdeba0555086d51de1090df325e18ee8da9c8'
-BDB_URL="https://download.oracle.com/berkeley-db/${BDB_VERSION}.tar.gz"
+BDB_VERSION='db-18.1.32'
+BDB_HASH='fa1fe7de9ba91ad472c25d026f931802597c29f28ae951960685cde487c8d654'
+# As of 5th March 2020 this mirror is identical to Oracle's login-protected tarball for db 18.1.32
+BDB_URL="https://bintray.com/homebrew/mirror/download_file?file_path=berkeley-${BDB_VERSION}.tar.gz"
 
 check_exists() {
   which "$1" >/dev/null 2>&1
@@ -98,4 +99,4 @@ echo
 echo 'When compiling btcud, run `./configure` in the following way:'
 echo
 echo "  export BDB_PREFIX='${BDB_PREFIX}'"
-echo '  ./configure BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include" ...'
+echo '  ./configure BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-18.1" BDB_CFLAGS="-I${BDB_PREFIX}/include" ...'

--- a/depends/packages/static/berkeley-db-18.1.32/.gitignore
+++ b/depends/packages/static/berkeley-db-18.1.32/.gitignore
@@ -1,0 +1,1 @@
+!berkeley-db-18.1.32.tar.gz

--- a/depends/packages/static/berkeley-db-18.1.32/README.MD
+++ b/depends/packages/static/berkeley-db-18.1.32/README.MD
@@ -1,0 +1,7 @@
+## Berkeley DB
+Since as of 5th March 2020 the Oracle moved Barkeley DB to login-protected tarball for 18.1.32 version we added the dependency as a static file included in the repository.
+
+File: berkeley-db-18.1.32.tar.gz
+SHA256: fa1fe7de9ba91ad472c25d026f931802597c29f28ae951960685cde487c8d654
+
+For the detailed description of the version please check [official documentation](https://download.oracle.com/otndocs/products/berkeleydb/html/changelog_18_1.html#idm140649573044560)

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -117,16 +117,15 @@ If exists previous version like 4.8 (Bitcoin default) then remove:
     
     sudo apt-get purge libdb4.8-dev libdb4.8++-dev
         
+Since as of 5th March 2020 the Oracle moved Barkeley DB to login-protected tarball for 18.1.32 version we added the dependency as a static file included in the repository.
+
 Install:
 
-    wget http://download.oracle.com/berkeley-db/db-18.1.40.tar.gz
-    tar zxvf db-18.1.40.tar.gz
-    cd  db-18.1.40/build_unix
+    tar zxvf depends/packages/static/berkeley-db-18.1.32/berkeley-db-18.1.32.tar.gz -C ./
+    cd  db-18.1.32/build_unix
     ../dist/configure --enable-cxx --disable-shared --disable-replication --with-pic --prefix=/opt
     make
     sudo make install
-    
-Some errors of 'cp'  command may occur after make install, but it's okay.
 
 Run btcu project configure:
     
@@ -315,7 +314,7 @@ disable-wallet mode with:
 
     ./configure --disable-wallet
 
-In this case there is no dependency on Berkeley DB 4.8.
+In this case there is no dependency on Berkeley DB 18.1.
 
 
 Additional Configure Flags

--- a/install_ubuntu.sh
+++ b/install_ubuntu.sh
@@ -40,9 +40,14 @@ else
 sudo apt-get install libboost-all-dev
 
 sudo apt-get purge libdb4.8-dev libdb4.8++-dev
-wget http://download.oracle.com/berkeley-db/db-18.1.40.tar.gz
-tar zxvf db-18.1.40.tar.gz
-cd  db-18.1.40/build_unix
+
+# Since as of 5th March 2020 the Oracle moved Barkeley DB 
+# to login-protected tarball for 18.1.32 version 
+# we added the dependency as a static file included in the repository.
+# You can check the details in depends/packages/static/berkeley-db-18.1.32/README.MD
+
+tar zxvf depends/packages/static/berkeley-db-18.1.32/berkeley-db-18.1.32.tar.gz -C ./
+cd  db-18.1.32/build_unix
 ../dist/configure --enable-cxx --disable-shared --disable-replication --with-pic --prefix=/opt
 make
 


### PR DESCRIPTION
Since the Berkeley DB 18.1.40 has a build defects and within it was removed SQL support it is recommended to downgrade the version to previous stable version which is 18.1.32.

Also as of 5th March 2020 the Oracle moved Berkeley DB to login-protected tarball for 18.1.32 version so it was added as a static file included in the repository.